### PR TITLE
Like toggle, keyboard QOL changes

### DIFF
--- a/Here/Models/Post.swift
+++ b/Here/Models/Post.swift
@@ -17,6 +17,7 @@ struct Post: Identifiable, Codable {
     let createdAt: Date
     let expiresAt: Date
     var likeCount: Int
+    var likedBy: [String]
 
     init(
         id: String? = nil,
@@ -25,7 +26,8 @@ struct Post: Identifiable, Codable {
         imageURLs: [String] = [],
         authorUID: String,
         createdAt: Date = Date(),
-        likeCount: Int = 0
+        likeCount: Int = 0,
+        likedBy: [String] = []
     ) {
         self.id = id
         self.title = title
@@ -35,10 +37,19 @@ struct Post: Identifiable, Codable {
         self.createdAt = createdAt
         self.expiresAt = createdAt.addingTimeInterval(24 * 60 * 60)
         self.likeCount = likeCount
+        self.likedBy = likedBy
     }
-    /// A post is valid if it has a title and at least some description content (text or images)
-//    var hasContent: Bool {
-//        !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-//            && (!bodyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || !images.isEmpty)
-//    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        _id = try c.decode(DocumentID<String>.self, forKey: .id)
+        title = try c.decode(String.self, forKey: .title)
+        bodyText = try c.decodeIfPresent(String.self, forKey: .bodyText) ?? ""
+        imageURLs = try c.decodeIfPresent([String].self, forKey: .imageURLs) ?? []
+        authorUID = try c.decode(String.self, forKey: .authorUID)
+        createdAt = try c.decode(Date.self, forKey: .createdAt)
+        expiresAt = try c.decode(Date.self, forKey: .expiresAt)
+        likeCount = try c.decodeIfPresent(Int.self, forKey: .likeCount) ?? 0
+        likedBy = try c.decodeIfPresent([String].self, forKey: .likedBy) ?? []
+    }
 }

--- a/Here/State/AppState.swift
+++ b/Here/State/AppState.swift
@@ -112,12 +112,12 @@ final class AppState: ObservableObject {
         }
     }
   
-    func toggleLike(post: Post) async {
-        guard let postId = post.id else { return }
-        let alreadyLiked = post.likedBy.contains(uid)
+    func toggleLike(post: Post, alreadyLiked: Bool) async {
+        guard let postId = post.id, !uid.isEmpty else { return }
+        let countDelta = alreadyLiked ? (post.likeCount > 0 ? Int64(-1) : Int64(0)) : Int64(1)
         do {
             try await db.collection("posts").document(postId).updateData([
-                "likeCount": FieldValue.increment(Int64(alreadyLiked ? -1 : 1)),
+                "likeCount": FieldValue.increment(countDelta),
                 "likedBy": alreadyLiked ? FieldValue.arrayRemove([uid]) : FieldValue.arrayUnion([uid])
             ])
         } catch {

--- a/Here/State/AppState.swift
+++ b/Here/State/AppState.swift
@@ -112,13 +112,16 @@ final class AppState: ObservableObject {
         }
     }
   
-    func likePost(postId: String) async {
+    func toggleLike(post: Post) async {
+        guard let postId = post.id else { return }
+        let alreadyLiked = post.likedBy.contains(uid)
         do {
             try await db.collection("posts").document(postId).updateData([
-                "likeCount": FieldValue.increment(Int64(1))
+                "likeCount": FieldValue.increment(Int64(alreadyLiked ? -1 : 1)),
+                "likedBy": alreadyLiked ? FieldValue.arrayRemove([uid]) : FieldValue.arrayUnion([uid])
             ])
         } catch {
-            print("Error liking post: \(error.localizedDescription)")
+            print("Error toggling like: \(error.localizedDescription)")
         }
     }
 

--- a/Here/Views/ChatDetailView.swift
+++ b/Here/Views/ChatDetailView.swift
@@ -111,14 +111,14 @@ struct ChatDetailView: View {
     // MARK: - Input Bar
     private var chatInputBar: some View {
         HStack(spacing: 12) {
-            TextField("", text: $input)
+            TextField("", text: $input, axis: .vertical)
                 .font(.system(size: 15, weight: .light))
                 .padding(.horizontal, 16)
                 .padding(.vertical, 10)
                 .background(Color.white)
-                .clipShape(Capsule())
+                .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
                 .overlay(
-                    Capsule()
+                    RoundedRectangle(cornerRadius: 20, style: .continuous)
                         .stroke(Color(hex: "#E8E0CC"), lineWidth: 1)
                 )
 

--- a/Here/Views/ChatDetailView.swift
+++ b/Here/Views/ChatDetailView.swift
@@ -44,6 +44,7 @@ struct ChatDetailView: View {
                 .padding(.vertical, 12)
             }
             .defaultScrollAnchor(.bottom)
+            .scrollDismissesKeyboard(.interactively)
             .onChange(of: messages.count) {
                 if let lastId = messages.last?.id {
                     withAnimation { proxy.scrollTo(lastId, anchor: .bottom) }

--- a/Here/Views/ChatDetailView.swift
+++ b/Here/Views/ChatDetailView.swift
@@ -110,7 +110,7 @@ struct ChatDetailView: View {
 
     // MARK: - Input Bar
     private var chatInputBar: some View {
-        HStack(spacing: 12) {
+        HStack(alignment: .bottom, spacing: 12) {
             TextField("", text: $input, axis: .vertical)
                 .font(.system(size: 15, weight: .light))
                 .padding(.horizontal, 16)

--- a/Here/Views/ChatDetailView.swift
+++ b/Here/Views/ChatDetailView.swift
@@ -32,29 +32,24 @@ struct ChatDetailView: View {
     }
 
     var body: some View {
-        ZStack {
-            Color.white.ignoresSafeArea()
-
-            VStack(spacing: 0) {
-                ScrollViewReader { proxy in
-                    ScrollView {
-                        LazyVStack(spacing: 10) {
-                            ForEach(messages) { m in
-                                MessageBubble(message: m, uid: uid)
-                                    .id(m.id)
-                            }
-                        }
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 12)
-                    }
-                    .defaultScrollAnchor(.bottom)              
-                    .onChange(of: messages.count) {
-                        if let lastId = messages.last?.id {
-                            withAnimation { proxy.scrollTo(lastId, anchor: .bottom) }
-                        }
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: 10) {
+                    ForEach(messages) { m in
+                        MessageBubble(message: m, uid: uid)
+                            .id(m.id)
                     }
                 }
-
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
+            }
+            .defaultScrollAnchor(.bottom)
+            .onChange(of: messages.count) {
+                if let lastId = messages.last?.id {
+                    withAnimation { proxy.scrollTo(lastId, anchor: .bottom) }
+                }
+            }
+            .safeAreaInset(edge: .bottom, spacing: 0) {
                 if !frozen {
                     chatInputBar
                 } else {
@@ -62,6 +57,7 @@ struct ChatDetailView: View {
                 }
             }
         }
+        .background(Color.white.ignoresSafeArea())
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(Color.white, for: .navigationBar)
         .toolbar {

--- a/Here/Views/ContentView.swift
+++ b/Here/Views/ContentView.swift
@@ -2,11 +2,11 @@ import SwiftUI
 
 struct ContentView: View {
     @EnvironmentObject var authService: AuthService
-    
+
     @State private var selectedTab: MainTab = .feed
-    @State private var lastNonCreateTab: MainTab = .feed
     @State private var showCreateSheet = false
     @State private var heartBeating = false
+    @State private var showTabBar = true
 
     @StateObject private var app = AppState(authService: AuthService())
 
@@ -38,39 +38,42 @@ struct ContentView: View {
     }
 
     private var mainTabView: some View {
-        ZStack(alignment: .bottom) {
-            Color.black.ignoresSafeArea()
+        TabView(selection: $selectedTab) {
+            VoiceView()
+                .tag(MainTab.voice)
 
-            TabView(selection: $selectedTab) {
-                VoiceView()
-                    .tag(MainTab.voice)
-
-                FeedView(
-                    posts: app.posts,
-                    uid: app.uid,
-                    onStartChat: { post in
-                        Task {
-                            _ = await app.createThreadFromPost(post)
-                            selectedTab = .inbox
-                        }
-                    },
-                    onToggleLike: { post in
-                        Task { await app.toggleLike(post: post) }
+            FeedView(
+                posts: app.posts,
+                uid: app.uid,
+                onStartChat: { post in
+                    Task {
+                        _ = await app.createThreadFromPost(post)
+                        selectedTab = .inbox
                     }
-                )
-                .tag(MainTab.feed)
+                },
+                onToggleLike: { post in
+                    Task { await app.toggleLike(post: post) }
+                }
+            )
+            .tag(MainTab.feed)
 
+            Color.clear.tag(MainTab.create)
 
-                Color.clear.tag(MainTab.create)
+            InboxView(app: app)
+                .tag(MainTab.inbox)
 
-                InboxView(app: app)
-                    .tag(MainTab.inbox)
-
-                ProfileView()
-                    .tag(MainTab.profile)
-            }
-            .toolbar(.hidden, for: .tabBar)
-
+            ProfileView()
+                .tag(MainTab.profile)
+        }
+        .toolbar(.hidden, for: .tabBar)
+        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { _ in
+            withAnimation(.easeInOut(duration: 0.25)) { showTabBar = false }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
+            withAnimation(.easeInOut(duration: 0.25)) { showTabBar = true }
+        }
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+          if showTabBar {
             HStack(spacing: 0) {
                 CustomTabItem(
                     iconDefault: "waveform",
@@ -91,15 +94,11 @@ struct ContentView: View {
                     startHeartbeat()
                     showCreateSheet = true
                 } label: {
-                    ZStack {
-                        Image(systemName: "heart.fill")
-                            .font(.system(size: 44, weight: .thin))
-                            .foregroundStyle(goldGradient)
-                            .shadow(color: Color(hex: "#C9A84C").opacity(0.4), radius: 6, y: 2)
-                            .scaleEffect(heartBeating ? 1.25 : 1.0)
-                    }
-                    .scaleEffect(heartBeating ? 1.25 : 1.0)
-                    
+                    Image(systemName: "heart.fill")
+                        .font(.system(size: 44, weight: .thin))
+                        .foregroundStyle(goldGradient)
+                        .shadow(color: Color(hex: "#C9A84C").opacity(0.4), radius: 6, y: 2)
+                        .scaleEffect(heartBeating ? 1.25 : 1.0)
                 }
                 .frame(maxWidth: .infinity)
 
@@ -121,6 +120,7 @@ struct ContentView: View {
             .padding(.horizontal, 12)
             .padding(.top, 8)
             .background(.ultraThinMaterial)
+          }
         }
         .sheet(isPresented: $showCreateSheet) {
             CreatePostView(app: app)

--- a/Here/Views/ContentView.swift
+++ b/Here/Views/ContentView.swift
@@ -24,6 +24,7 @@ struct ContentView: View {
                 app.authService = authService
                 app.startListening()
             }
+            KeyboardDismisser.install()
         }
         .onChange(of: authService.isSignedIn) {
             print("isSignedIn changed to: \(authService.isSignedIn)")
@@ -194,6 +195,25 @@ struct CustomTabItem: View {
             .frame(maxWidth: .infinity)
         }
         .animation(.easeInOut(duration: 0.2), value: isSelected)
+    }
+}
+
+// MARK: - Keyboard Dismisser
+private final class KeyboardDismisser: NSObject {
+    static let shared = KeyboardDismisser()
+
+    static func install() {
+        guard let window = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .flatMap({ $0.windows })
+            .first(where: { $0.isKeyWindow }) else { return }
+        let tap = UITapGestureRecognizer(target: shared, action: #selector(dismiss))
+        tap.cancelsTouchesInView = false
+        window.addGestureRecognizer(tap)
+    }
+
+    @objc private func dismiss() {
+        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
     }
 }
 

--- a/Here/Views/ContentView.swift
+++ b/Here/Views/ContentView.swift
@@ -47,14 +47,15 @@ struct ContentView: View {
 
                 FeedView(
                     posts: app.posts,
+                    uid: app.uid,
                     onStartChat: { post in
                         Task {
                             _ = await app.createThreadFromPost(post)
                             selectedTab = .inbox
                         }
                     },
-                    onLike: { id in
-                        Task { await app.likePost(postId: id) }
+                    onToggleLike: { post in
+                        Task { await app.toggleLike(post: post) }
                     }
                 )
                 .tag(MainTab.feed)

--- a/Here/Views/ContentView.swift
+++ b/Here/Views/ContentView.swift
@@ -52,8 +52,8 @@ struct ContentView: View {
                         selectedTab = .inbox
                     }
                 },
-                onToggleLike: { post in
-                    Task { await app.toggleLike(post: post) }
+                onToggleLike: { post, alreadyLiked in
+                    Task { await app.toggleLike(post: post, alreadyLiked: alreadyLiked) }
                 }
             )
             .tag(MainTab.feed)
@@ -202,7 +202,10 @@ struct CustomTabItem: View {
 private final class KeyboardDismisser: NSObject {
     static let shared = KeyboardDismisser()
 
+    private static var isInstalled = false
+
     static func install() {
+        guard !isInstalled else { return }
         guard let window = UIApplication.shared.connectedScenes
             .compactMap({ $0 as? UIWindowScene })
             .flatMap({ $0.windows })
@@ -210,6 +213,7 @@ private final class KeyboardDismisser: NSObject {
         let tap = UITapGestureRecognizer(target: shared, action: #selector(dismiss))
         tap.cancelsTouchesInView = false
         window.addGestureRecognizer(tap)
+        isInstalled = true
     }
 
     @objc private func dismiss() {

--- a/Here/Views/FeedView.swift
+++ b/Here/Views/FeedView.swift
@@ -2,8 +2,9 @@ import SwiftUI
 
 struct FeedView: View {
     let posts: [Post]
+    let uid: String
     let onStartChat: (Post) -> Void
-    let onLike: (String) -> Void
+    let onToggleLike: (Post) -> Void
 
     var body: some View {
         if posts.isEmpty {
@@ -28,8 +29,9 @@ struct FeedView: View {
                     ForEach(posts) { post in
                         SinglePostView(
                             post: post,
+                            uid: uid,
                             onStartChat: onStartChat,
-                            onLike: onLike
+                            onToggleLike: onToggleLike
                         )
                         .containerRelativeFrame(.vertical)
                     }
@@ -44,12 +46,14 @@ struct FeedView: View {
 // MARK: - Single Post
 struct SinglePostView: View {
     let post: Post
+    let uid: String
     let onStartChat: (Post) -> Void
-    let onLike: (String) -> Void
+    let onToggleLike: (Post) -> Void
 
-    @State private var liked = false
     @State private var likeScale = 1.0
     @State private var showReport = false
+
+    private var liked: Bool { post.likedBy.contains(uid) }
 
     var goldGradient: LinearGradient {
         LinearGradient(
@@ -63,7 +67,7 @@ struct SinglePostView: View {
         GeometryReader { geo in
             ZStack {
                 Color.white.ignoresSafeArea()
-                
+
                 // Background image if exists
                 if let firstURL = post.imageURLs.first, let url = URL(string: firstURL) {
                     AsyncImage(url: url) { phase in
@@ -74,11 +78,9 @@ struct SinglePostView: View {
                                 .scaledToFill()
                                 .frame(width: geo.size.width, height: geo.size.height)
                                 .clipped()
-                                //.overlay(Color.white.opacity(0.15))
                         case .failure:
                             EmptyView()
                         case .empty:
-                            //gradientFallback.overlay(ProgressView().tint(.white))
                             EmptyView()
                         @unknown default:
                             EmptyView()
@@ -86,7 +88,7 @@ struct SinglePostView: View {
                     }
                     .clipped()
                 }
-                
+
                 VStack(spacing: 0) {
                     // Scrollable content area - centered
                     ScrollView(.vertical, showsIndicators: false) {
@@ -94,14 +96,14 @@ struct SinglePostView: View {
                             Text(post.title)
                                 .font(.system(size: 24, weight: .light))
                                 .foregroundColor(.black)
-                            
+
                             if !post.bodyText.isEmpty {
                                 Text(post.bodyText)
                                     .font(.system(size: 16, weight: .light))
                                     .foregroundColor(Color(hex: "#5C5C5C"))
                                     .lineSpacing(6)
                             }
-                            
+
                             // Extra image thumbnails
                             if post.imageURLs.count > 1 {
                                 ScrollView(.horizontal, showsIndicators: false) {
@@ -124,16 +126,12 @@ struct SinglePostView: View {
                         .padding(.horizontal, 28)
                         .frame(minHeight: geo.size.height - 140, alignment: .center)
                     }
-                    
+
                     // Action buttons — always pinned at bottom
                     HStack(spacing: 20) {
                         // Like button
                         Button {
-                            guard !liked else { return }
-                            liked = true
-                            if let postId = post.id {
-                                onLike(postId)
-                            }
+                            onToggleLike(post)
                             withAnimation(.spring(response: 0.3, dampingFraction: 0.4)) {
                                 likeScale = 1.4
                             }
@@ -157,7 +155,7 @@ struct SinglePostView: View {
                                     .foregroundColor(liked ? Color(hex: "#C9A84C") : Color(hex: "#D4C5A0"))
                             }
                         }
-                        
+
                         // Chat button
                         Button {
                             onStartChat(post)
@@ -175,9 +173,9 @@ struct SinglePostView: View {
                             .background(goldGradient)
                             .clipShape(Capsule())
                         }
-                        
+
                         Spacer()
-                        
+
                         // Report menu
                         Menu {
                             Button(role: .destructive) {
@@ -203,13 +201,6 @@ struct SinglePostView: View {
             Text("Thank you for helping keep this space safe.")
         }
     }
-//    private var gradientFallback: some View {
-//        LinearGradient(
-//            colors: [.black, Color(.darkGray)],
-//            startPoint: .topLeading,
-//            endPoint: .bottomTrailing
-//        )
-//    }
 }
 
 #Preview {
@@ -219,7 +210,8 @@ struct SinglePostView: View {
             Post(title: "Can't sleep", bodyText: "Anyone else up late thinking about everything?", authorUID: "preview"),
             Post(title: "New here", bodyText: "Just downloaded this app. Excited to connect.", authorUID: "preview")
         ],
+        uid: "preview",
         onStartChat: { _ in },
-        onLike: { _ in }
+        onToggleLike: { _ in }
     )
 }

--- a/Here/Views/FeedView.swift
+++ b/Here/Views/FeedView.swift
@@ -4,7 +4,7 @@ struct FeedView: View {
     let posts: [Post]
     let uid: String
     let onStartChat: (Post) -> Void
-    let onToggleLike: (Post) -> Void
+    let onToggleLike: (Post, Bool) -> Void
 
     var body: some View {
         if posts.isEmpty {
@@ -48,12 +48,19 @@ struct SinglePostView: View {
     let post: Post
     let uid: String
     let onStartChat: (Post) -> Void
-    let onToggleLike: (Post) -> Void
+    let onToggleLike: (Post, Bool) -> Void
 
     @State private var likeScale = 1.0
     @State private var showReport = false
+    @State private var optimisticLiked: Bool? = nil
 
-    private var liked: Bool { post.likedBy.contains(uid) }
+    private var liked: Bool { optimisticLiked ?? post.likedBy.contains(uid) }
+    private var displayCount: Int {
+        guard let optimistic = optimisticLiked else { return post.likeCount }
+        let serverLiked = post.likedBy.contains(uid)
+        guard optimistic != serverLiked else { return post.likeCount }
+        return max(0, post.likeCount + (optimistic ? 1 : -1))
+    }
 
     var goldGradient: LinearGradient {
         LinearGradient(
@@ -131,13 +138,17 @@ struct SinglePostView: View {
                     HStack(spacing: 20) {
                         // Like button
                         Button {
-                            onToggleLike(post)
-                            withAnimation(.spring(response: 0.3, dampingFraction: 0.4)) {
-                                likeScale = 1.4
-                            }
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-                                withAnimation(.spring(response: 0.3, dampingFraction: 0.6)) {
-                                    likeScale = 1.0
+                            let currentLiked = liked
+                            optimisticLiked = !currentLiked
+                            onToggleLike(post, currentLiked)
+                            if !currentLiked {
+                                withAnimation(.spring(response: 0.3, dampingFraction: 0.4)) {
+                                    likeScale = 1.4
+                                }
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+                                    withAnimation(.spring(response: 0.3, dampingFraction: 0.6)) {
+                                        likeScale = 1.0
+                                    }
                                 }
                             }
                         } label: {
@@ -150,9 +161,12 @@ struct SinglePostView: View {
                                         : LinearGradient(colors: [Color(hex: "#D4C5A0")], startPoint: .top, endPoint: .bottom)
                                     )
                                     .scaleEffect(likeScale)
-                                Text("\(post.likeCount)")
+                                    .frame(width: 22)
+                                Text("\(displayCount)")
                                     .font(.system(size: 13, weight: .light))
+                                    .monospacedDigit()
                                     .foregroundColor(liked ? Color(hex: "#C9A84C") : Color(hex: "#D4C5A0"))
+                                    .frame(minWidth: 16, alignment: .leading)
                             }
                         }
 
@@ -194,6 +208,11 @@ struct SinglePostView: View {
                 }
             }
         }
+        .onChange(of: post.likedBy) {
+            if let optimistic = optimisticLiked, post.likedBy.contains(uid) == optimistic {
+                optimisticLiked = nil
+            }
+        }
         .alert("Report this post?", isPresented: $showReport) {
             Button("Report", role: .destructive) { }
             Button("Cancel", role: .cancel) { }
@@ -212,6 +231,6 @@ struct SinglePostView: View {
         ],
         uid: "preview",
         onStartChat: { _ in },
-        onToggleLike: { _ in }
+        onToggleLike: { _, _ in }
     )
 }


### PR DESCRIPTION
- add support for unlike, now each post tracks likes by user id so to support like/unlike #6 
- when keyboard opens, menu bar no longer moves right above keyboard, blocking the input bar (BUGFIX)
- you can now close keyboard by tapping/swiping outside
- pin send button to bottom for multi-line input