### PR TITLE
Add Notifications Support

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "here-a6817"
+  }
+}

--- a/Configs/Shared.xcconfig
+++ b/Configs/Shared.xcconfig
@@ -9,4 +9,12 @@
 DEVELOPMENT_TEAM = GBMC68KS5K
 PRODUCT_BUNDLE_IDENTIFIER = dev.hylee.Here
 
+// Push notifications need the paid Apple Developer Program — free personal
+// teams can't sign the aps-environment entitlement, so it's off by default.
+// On a paid team, enable it here (or in Local.xcconfig):
+//
+//   HERE_PUSH_ENTITLEMENTS = Here/Here.entitlements
+//
+HERE_PUSH_ENTITLEMENTS =
+
 #include? "Local.xcconfig"

--- a/Here.xcodeproj/project.pbxproj
+++ b/Here.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		93E7A1322F53BD2C003F6FE6 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 93E7A1312F53BD2C003F6FE6 /* FirebaseAuth */; };
 		93E7A1342F53BD2C003F6FE6 /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = 93E7A1332F53BD2C003F6FE6 /* FirebaseFirestore */; };
 		93E7A1362F53BD2C003F6FE6 /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 93E7A1352F53BD2C003F6FE6 /* FirebaseStorage */; };
+		93E7A1382F53BD2C003F6FE6 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 93E7A1372F53BD2C003F6FE6 /* FirebaseMessaging */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -62,6 +63,7 @@
 				93E7A1322F53BD2C003F6FE6 /* FirebaseAuth in Frameworks */,
 				93E7A1342F53BD2C003F6FE6 /* FirebaseFirestore in Frameworks */,
 				93E7A1362F53BD2C003F6FE6 /* FirebaseStorage in Frameworks */,
+				93E7A1382F53BD2C003F6FE6 /* FirebaseMessaging in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -126,6 +128,7 @@
 				93E7A1312F53BD2C003F6FE6 /* FirebaseAuth */,
 				93E7A1332F53BD2C003F6FE6 /* FirebaseFirestore */,
 				93E7A1352F53BD2C003F6FE6 /* FirebaseStorage */,
+				93E7A1372F53BD2C003F6FE6 /* FirebaseMessaging */,
 			);
 			productName = Here;
 			productReference = 93E7A0E92F3EE40D003F6FE6 /* Here.app */;
@@ -413,12 +416,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "$(HERE_PUSH_ENTITLEMENTS)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UIBackgroundModes = "remote-notification";
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -440,12 +445,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "$(HERE_PUSH_ENTITLEMENTS)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UIBackgroundModes = "remote-notification";
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -600,6 +607,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 93E7A1302F53BD2C003F6FE6 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseStorage;
+		};
+		93E7A1372F53BD2C003F6FE6 /* FirebaseMessaging */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 93E7A1302F53BD2C003F6FE6 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseMessaging;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Here/Here.entitlements
+++ b/Here/Here.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/Here/Models/ChatThread.swift
+++ b/Here/Models/ChatThread.swift
@@ -43,6 +43,7 @@ struct ChatThread: Identifiable, Codable, Equatable {
     var hasExtendedOnce: Bool
     var continueChoices: [String: String]  // [uid: "undecided"/"yes"/"no"]
     var nickname: String
+    var lastRead: [String: Date]  // [uid: last time that user opened this thread]
 
     init(
         id: String? = nil,
@@ -62,6 +63,7 @@ struct ChatThread: Identifiable, Codable, Equatable {
         self.isManuallyFrozen = false
         self.hasExtendedOnce = false
         self.nickname = nickname
+        self.lastRead = [:]
         var choices: [String: String] = [:]
         for uid in participants {
             choices[uid] = ContinueChoice.undecided.rawValue
@@ -118,7 +120,7 @@ struct ChatThread: Identifiable, Codable, Equatable {
     // Custom decoder so old Firestore documents without `nickname`/`postId` still decode.
     enum CodingKeys: String, CodingKey {
         case id, postId, postTitle, participants, createdAt, expiresAt
-        case isManuallyFrozen, hasExtendedOnce, continueChoices, nickname
+        case isManuallyFrozen, hasExtendedOnce, continueChoices, nickname, lastRead
     }
 
     init(from decoder: Decoder) throws {
@@ -134,6 +136,7 @@ struct ChatThread: Identifiable, Codable, Equatable {
         hasExtendedOnce  = (try? c.decode(Bool.self,              forKey: .hasExtendedOnce))  ?? false
         continueChoices  = (try? c.decode([String: String].self,  forKey: .continueChoices))  ?? [:]
         nickname         = (try? c.decode(String.self,            forKey: .nickname))          ?? ChatThread.generateNickname(seed: docId.wrappedValue)
+        lastRead         = (try? c.decode([String: Date].self,    forKey: .lastRead))          ?? [:]
     }
 }
 

--- a/Here/Services/PushManager.swift
+++ b/Here/Services/PushManager.swift
@@ -1,0 +1,109 @@
+import FirebaseFirestore
+import FirebaseMessaging
+import Foundation
+import UIKit
+import UserNotifications
+
+/// Owns everything push: permission, FCM token persistence, foreground
+/// presentation, and routing notification taps to the right chat thread.
+@MainActor
+final class PushManager: NSObject, ObservableObject {
+    static let shared = PushManager()
+
+    /// Thread the user is currently viewing — banners for it are suppressed.
+    var activeThreadId: String?
+
+    /// Set when the user taps a message notification; ContentView routes to it.
+    @Published var tappedThreadId: String?
+
+    private var uid: String?
+    private var pendingToken: String?
+
+    /// Call right after FirebaseApp.configure().
+    func configure() {
+        UNUserNotificationCenter.current().delegate = self
+        Messaging.messaging().delegate = self
+    }
+
+    /// Prompts for notification permission and registers with APNs.
+    func requestPermissionAndRegister() {
+        Task {
+            let granted = (try? await UNUserNotificationCenter.current()
+                .requestAuthorization(options: [.alert, .badge, .sound])) ?? false
+            if granted {
+                UIApplication.shared.registerForRemoteNotifications()
+            }
+        }
+    }
+
+    /// Once auth is ready, any token received earlier can be stored under the user.
+    func userSignedIn(uid: String) {
+        self.uid = uid
+        if let token = pendingToken {
+            saveToken(token)
+        }
+    }
+
+    func apnsTokenReceived(_ deviceToken: Data) {
+        Messaging.messaging().apnsToken = deviceToken
+    }
+
+    private func saveToken(_ token: String) {
+        guard let uid, !uid.isEmpty else {
+            // Token can arrive before anonymous sign-in completes
+            pendingToken = token
+            return
+        }
+        pendingToken = nil
+        Firestore.firestore().collection("users").document(uid).setData([
+            "fcmToken": token,
+            "tokenUpdatedAt": FieldValue.serverTimestamp()
+        ], merge: true)
+    }
+}
+
+// MARK: - MessagingDelegate
+
+extension PushManager: MessagingDelegate {
+    nonisolated func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
+        guard let fcmToken else { return }
+        Task { @MainActor in
+            self.saveToken(fcmToken)
+        }
+    }
+}
+
+// MARK: - UNUserNotificationCenterDelegate
+
+extension PushManager: UNUserNotificationCenterDelegate {
+    // Foreground: show the banner + buzz unless the user is already in that thread
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        let threadId = notification.request.content.userInfo["threadId"] as? String
+        Task { @MainActor in
+            if let threadId, threadId == self.activeThreadId {
+                completionHandler([])
+            } else {
+                completionHandler([.banner, .sound, .badge])
+            }
+        }
+    }
+
+    // Tapping a notification opens the conversation it belongs to
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        let threadId = response.notification.request.content.userInfo["threadId"] as? String
+        Task { @MainActor in
+            if let threadId {
+                self.tappedThreadId = threadId
+            }
+            completionHandler()
+        }
+    }
+}

--- a/Here/State/AppState.swift
+++ b/Here/State/AppState.swift
@@ -88,6 +88,13 @@ final class AppState: ObservableObject {
 
     // MARK: - Unread
 
+    /// When the conversation last had activity — its newest message, or the
+    /// thread's creation time before anyone has written.
+    func lastActivity(of thread: ChatThread) -> Date {
+        guard let threadId = thread.id else { return thread.createdAt }
+        return messages[threadId]?.last?.createdAt ?? thread.createdAt
+    }
+
     func unreadCount(in thread: ChatThread) -> Int {
         guard let threadId = thread.id, !uid.isEmpty else { return 0 }
         let lastRead = thread.lastRead[uid] ?? .distantPast

--- a/Here/State/AppState.swift
+++ b/Here/State/AppState.swift
@@ -36,6 +36,7 @@ final class AppState: ObservableObject {
         messageListeners.values.forEach { $0.remove() }
         messageListeners.removeAll()
         messages.removeAll()
+        lastSyncedBadge = nil
     }
 
     private func listenToPosts() {
@@ -121,12 +122,18 @@ final class AppState: ObservableObject {
         }
     }
 
+    private var lastSyncedBadge: Int?
+
     /// Mirrors the unread-conversation count onto the app icon and the
     /// server-side counter that push notifications use for their badge number.
+    /// Every message listener calls this, so skip when nothing changed —
+    /// otherwise app launch fires a burst of identical Firestore writes.
     private func syncBadge() {
-        let total = unreadThreadCount
-        UNUserNotificationCenter.current().setBadgeCount(total, withCompletionHandler: nil)
         guard !uid.isEmpty else { return }
+        let total = unreadThreadCount
+        guard total != lastSyncedBadge else { return }
+        lastSyncedBadge = total
+        UNUserNotificationCenter.current().setBadgeCount(total, withCompletionHandler: nil)
         db.collection("users").document(uid).setData(["unreadTotal": total], merge: true)
     }
 

--- a/Here/State/AppState.swift
+++ b/Here/State/AppState.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import FirebaseFirestore
+import UserNotifications
 
 @MainActor
 final class AppState: ObservableObject {
@@ -69,6 +70,7 @@ final class AppState: ObservableObject {
                         self.listenToMessages(threadId: threadId)
                     }
                 }
+                self.syncBadge()
             }
     }
 
@@ -80,7 +82,45 @@ final class AppState: ObservableObject {
                 guard let docs = snapshot?.documents else { return }
                 let msgs = docs.compactMap { try? $0.data(as: ChatMessage.self) }
                 self?.messages[threadId] = msgs
+                self?.syncBadge()
             }
+    }
+
+    // MARK: - Unread
+
+    func unreadCount(in thread: ChatThread) -> Int {
+        guard let threadId = thread.id, !uid.isEmpty else { return 0 }
+        let lastRead = thread.lastRead[uid] ?? .distantPast
+        return (messages[threadId] ?? [])
+            .filter { $0.senderUID != uid && $0.senderUID != "system" && $0.createdAt > lastRead }
+            .count
+    }
+
+    /// iMessage-style: number of conversations with unread messages,
+    /// not the total message count.
+    var unreadThreadCount: Int {
+        threads.filter { unreadCount(in: $0) > 0 }.count
+    }
+
+    /// Stamps "read up to now" for the current user on a thread.
+    func markThreadRead(threadId: String) async {
+        guard !uid.isEmpty else { return }
+        do {
+            try await db.collection("threads").document(threadId).updateData([
+                "lastRead.\(uid)": Timestamp(date: Date())
+            ])
+        } catch {
+            print("Error marking thread read: \(error.localizedDescription)")
+        }
+    }
+
+    /// Mirrors the unread-conversation count onto the app icon and the
+    /// server-side counter that push notifications use for their badge number.
+    private func syncBadge() {
+        let total = unreadThreadCount
+        UNUserNotificationCenter.current().setBadgeCount(total, withCompletionHandler: nil)
+        guard !uid.isEmpty else { return }
+        db.collection("users").document(uid).setData(["unreadTotal": total], merge: true)
     }
 
     // MARK: - Tags

--- a/Here/Views/ChatDetailView.swift
+++ b/Here/Views/ChatDetailView.swift
@@ -60,8 +60,13 @@ struct ChatDetailView: View {
                     .scrollDismissesKeyboard(.interactively)
                     .onChange(of: messages.count) {
                         withAnimation { proxy.scrollTo(Self.bottomAnchorId, anchor: .bottom) }
-                        // Still in the thread — anything that just arrived counts as read
-                        Task { await app.markThreadRead(threadId: threadId) }
+                        // Still in the thread — anything that just arrived counts as
+                        // read. Own/system messages never count as unread, so don't
+                        // burn a Firestore write re-stamping lastRead for them.
+                        if let last = messages.last,
+                           last.senderUID != uid, last.senderUID != "system" {
+                            Task { await app.markThreadRead(threadId: threadId) }
+                        }
                     }
                     .onAppear {
                         // Messages are usually loaded before this view is pushed, so

--- a/Here/Views/ChatDetailView.swift
+++ b/Here/Views/ChatDetailView.swift
@@ -60,6 +60,8 @@ struct ChatDetailView: View {
                     .scrollDismissesKeyboard(.interactively)
                     .onChange(of: messages.count) {
                         withAnimation { proxy.scrollTo(Self.bottomAnchorId, anchor: .bottom) }
+                        // Still in the thread — anything that just arrived counts as read
+                        Task { await app.markThreadRead(threadId: threadId) }
                     }
                     .onAppear {
                         // Messages are usually loaded before this view is pushed, so
@@ -67,6 +69,13 @@ struct ChatDetailView: View {
                         // layout after defaultScrollAnchor applies. Jump after layout.
                         DispatchQueue.main.async {
                             proxy.scrollTo(Self.bottomAnchorId, anchor: .bottom)
+                        }
+                        PushManager.shared.activeThreadId = threadId
+                        Task { await app.markThreadRead(threadId: threadId) }
+                    }
+                    .onDisappear {
+                        if PushManager.shared.activeThreadId == threadId {
+                            PushManager.shared.activeThreadId = nil
                         }
                     }
                 }

--- a/Here/Views/ContentView.swift
+++ b/Here/Views/ContentView.swift
@@ -29,6 +29,7 @@ struct ContentView: View {
             }
             KeyboardDismisser.install()
             KeyboardWarmer.warm()
+            routePendingNotificationTap()
         }
         .onChange(of: authService.isSignedIn) {
             print("isSignedIn changed to: \(authService.isSignedIn)")
@@ -41,12 +42,19 @@ struct ContentView: View {
             app.stopListening()
         }
         .onChange(of: push.tappedThreadId) {
-            // User tapped a message notification — jump into that conversation
-            guard let threadId = push.tappedThreadId else { return }
-            push.tappedThreadId = nil
-            navigateToThreadId = threadId
-            selectedTab = .inbox
+            routePendingNotificationTap()
         }
+    }
+
+    /// Jump into the conversation whose notification was tapped. Called from
+    /// onChange for taps while running, and from onAppear because a tap that
+    /// cold-launches the app can set tappedThreadId before this view exists —
+    /// onChange alone would never see it.
+    private func routePendingNotificationTap() {
+        guard let threadId = push.tappedThreadId else { return }
+        push.tappedThreadId = nil
+        navigateToThreadId = threadId
+        selectedTab = .inbox
     }
 
     private var mainTabView: some View {

--- a/Here/Views/ContentView.swift
+++ b/Here/Views/ContentView.swift
@@ -9,6 +9,7 @@ struct ContentView: View {
     @State private var heartBeating = false
     @State private var navigateToThreadId: String? = nil
     @State private var isChatOpen = false
+    @ObservedObject private var push = PushManager.shared
 
     @StateObject private var app = AppState(authService: AuthService())
 
@@ -38,6 +39,13 @@ struct ContentView: View {
         }
         .onDisappear {
             app.stopListening()
+        }
+        .onChange(of: push.tappedThreadId) {
+            // User tapped a message notification — jump into that conversation
+            guard let threadId = push.tappedThreadId else { return }
+            push.tappedThreadId = nil
+            navigateToThreadId = threadId
+            selectedTab = .inbox
         }
     }
 
@@ -124,7 +132,8 @@ struct ContentView: View {
                     iconSelected: "envelope.open",
                     label: "Chats",
                     tab: .inbox,
-                    selected: $selectedTab
+                    selected: $selectedTab,
+                    badge: app.unreadThreadCount
                 )
                 CustomTabItem(
                     iconDefault: "person.icloud",
@@ -181,6 +190,7 @@ struct CustomTabItem: View {
     let label: String
     let tab: MainTab
     @Binding var selected: MainTab
+    var badge: Int = 0
 
     var isSelected: Bool { selected == tab }
 
@@ -206,6 +216,17 @@ struct CustomTabItem: View {
                 Image(systemName: isSelected ? iconSelected : iconDefault)
                     .font(.system(size: 20, weight: .light))
                     .foregroundStyle(isSelected ? goldGradient : dimGoldGradient)
+                    .overlay(alignment: .topTrailing) {
+                        if badge > 0 {
+                            Text(badge > 99 ? "99+" : "\(badge)")
+                                .font(.system(size: 10, weight: .medium))
+                                .foregroundColor(.white)
+                                .padding(.horizontal, 5)
+                                .padding(.vertical, 2)
+                                .background(Capsule().fill(goldGradient))
+                                .offset(x: 12, y: -8)
+                        }
+                    }
 
                 Text(label)
                     .font(.system(size: 10, weight: .regular))

--- a/Here/Views/HereApp.swift
+++ b/Here/Views/HereApp.swift
@@ -13,7 +13,23 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
         FirebaseApp.configure()
+        PushManager.shared.configure()
         return true
+    }
+
+    func application(
+        _ application: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        PushManager.shared.apnsTokenReceived(deviceToken)
+    }
+
+    func application(
+        _ application: UIApplication,
+        didFailToRegisterForRemoteNotificationsWithError error: Error
+    ) {
+        // Expected on the simulator; harmless there
+        print("APNs registration failed: \(error.localizedDescription)")
     }
 }
 
@@ -31,6 +47,10 @@ struct HereApp: App {
                 .preferredColorScheme(.light)
                 .task {
                     await authService.signInAnonymously()
+                    if let uid = authService.uid {
+                        PushManager.shared.userSignedIn(uid: uid)
+                    }
+                    PushManager.shared.requestPermissionAndRegister()
                 }
         }
     }

--- a/Here/Views/InboxView.swift
+++ b/Here/Views/InboxView.swift
@@ -33,7 +33,7 @@ struct InboxView: View {
                     if !activeThreads.isEmpty {
                         ForEach(activeThreads) { thread in
                             NavigationLink(value: thread.id ?? "") {
-                                ThreadCard(thread: thread, isEnded: false, app: app)
+                                ThreadCard(thread: thread, isEnded: false, app: app, unreadCount: app.unreadCount(in: thread))
                             }
                             .listRowBackground(Color.white)
                             .listRowSeparator(.hidden)
@@ -44,7 +44,7 @@ struct InboxView: View {
                     if !endedThreads.isEmpty {
                         ForEach(endedThreads) { thread in
                             NavigationLink(value: thread.id ?? "") {
-                                ThreadCard(thread: thread, isEnded: true, app: app)
+                                ThreadCard(thread: thread, isEnded: true, app: app, unreadCount: app.unreadCount(in: thread))
                             }
                             .listRowBackground(Color.white)
                             .listRowSeparator(.hidden)
@@ -80,8 +80,7 @@ struct ThreadCard: View {
     let isEnded: Bool
     @ObservedObject var app: AppState
 
-    // 假设未读数，之后可以加到 ChatThread model 里
-    let unreadCount: Int = 0
+    let unreadCount: Int
 
     var lastMessage: String {
         let threadId = thread.id ?? ""

--- a/Here/Views/InboxView.swift
+++ b/Here/Views/InboxView.swift
@@ -10,8 +10,15 @@ struct InboxView: View {
 
     @State private var navigationPath = NavigationPath()
 
-    var activeThreads: [ChatThread] { app.threads.filter { !$0.isFrozen() } }
-    var endedThreads: [ChatThread] { app.threads.filter { $0.isFrozen() } }
+    // Most recently active conversations first, like iMessage
+    var activeThreads: [ChatThread] {
+        app.threads.filter { !$0.isFrozen() }
+            .sorted { app.lastActivity(of: $0) > app.lastActivity(of: $1) }
+    }
+    var endedThreads: [ChatThread] {
+        app.threads.filter { $0.isFrozen() }
+            .sorted { app.lastActivity(of: $0) > app.lastActivity(of: $1) }
+    }
 
     private func tryNavigate() {
         guard let threadId = navigateToThreadId,

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,5 @@
+{
+  "functions": {
+    "source": "functions"
+  }
+}

--- a/firebase.json
+++ b/firebase.json
@@ -1,5 +1,8 @@
 {
   "functions": {
     "source": "functions"
+  },
+  "firestore": {
+    "rules": "firestore.rules"
   }
 }

--- a/firebase.json
+++ b/firebase.json
@@ -4,5 +4,8 @@
   },
   "firestore": {
     "rules": "firestore.rules"
+  },
+  "storage": {
+    "rules": "storage.rules"
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,55 @@
+rules_version = '2';
+
+// Deploy with: firebase deploy --only firestore:rules
+// (or paste into Firebase Console → Firestore → Rules)
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    function signedIn() {
+      return request.auth != null;
+    }
+
+    match /posts/{postId} {
+      // NOTE: private ("just for me") posts are currently filtered client-side
+      // only — the feed queries the whole collection, so read access must stay
+      // collection-wide. Locking isPrivate posts down server-side requires
+      // changing the app's queries first.
+      allow read: if signedIn();
+      // You can only create posts as yourself
+      allow create: if signedIn()
+        && request.resource.data.authorUID == request.auth.uid;
+      // Author can edit their post; everyone else may only touch like fields
+      allow update: if signedIn() && (
+        resource.data.authorUID == request.auth.uid ||
+        request.resource.data.diff(resource.data)
+          .affectedKeys().hasOnly(['likeCount', 'likedBy'])
+      );
+      allow delete: if signedIn()
+        && resource.data.authorUID == request.auth.uid;
+    }
+
+    match /threads/{threadId} {
+      // Only the two participants can see or update a conversation
+      allow read, update: if signedIn()
+        && request.auth.uid in resource.data.participants;
+      // You can only create a thread you are part of
+      allow create: if signedIn()
+        && request.auth.uid in request.resource.data.participants;
+
+      match /messages/{messageId} {
+        allow read, create: if signedIn()
+          && request.auth.uid in
+            get(/databases/$(database)/documents/threads/$(threadId))
+              .data.participants;
+      }
+    }
+
+    // fcmToken + unreadTotal live here. Only the owner may touch their doc —
+    // otherwise anyone could overwrite someone else's push token and receive
+    // their message notifications. (The Cloud Function uses the Admin SDK,
+    // which bypasses rules, so it still works.)
+    match /users/{userId} {
+      allow read, write: if signedIn() && request.auth.uid == userId;
+    }
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -37,10 +37,18 @@ service cloud.firestore {
         && request.auth.uid in request.resource.data.participants;
 
       match /messages/{messageId} {
-        allow read, create: if signedIn()
+        allow read: if signedIn()
           && request.auth.uid in
             get(/databases/$(database)/documents/threads/$(threadId))
               .data.participants;
+        // senderUID is pinned so a participant can't forge messages as the
+        // other person. 'system' stays writable because the app itself creates
+        // system messages from the client (thread start, extensions).
+        allow create: if signedIn()
+          && request.auth.uid in
+            get(/databases/$(database)/documents/threads/$(threadId))
+              .data.participants
+          && request.resource.data.senderUID in [request.auth.uid, 'system'];
       }
     }
 

--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.log

--- a/functions/index.js
+++ b/functions/index.js
@@ -34,6 +34,11 @@ exports.notifyNewMessage = onDocumentCreated(
       // Badge counts unread CONVERSATIONS (like iMessage), so only bump it
       // when this thread flips from read to unread — i.e. the new message is
       // the only unread one from the other participant.
+      //
+      // Known race: two near-simultaneous messages can each see themselves as
+      // the first unread one and double-bump the badge. Accepted — the client
+      // rewrites the exact count whenever the recipient opens the app, so any
+      // drift is short-lived and cosmetic (badge number on the lock screen).
       const lastRead = (thread.lastRead || {})[recipient];
       let recentQuery = db.collection(`threads/${threadId}/messages`)
           .orderBy("createdAt", "desc")

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,0 +1,83 @@
+const {onDocumentCreated} = require("firebase-functions/v2/firestore");
+const admin = require("firebase-admin");
+
+admin.initializeApp();
+
+/**
+ * Sends a push notification to the other participant whenever a new chat
+ * message is written. Also bumps their server-side unread counter so the
+ * app-icon badge number on the push is roughly right even while the app
+ * is closed (the client rewrites the exact total whenever it's opened or
+ * a thread is read).
+ */
+exports.notifyNewMessage = onDocumentCreated(
+    "threads/{threadId}/messages/{messageId}",
+    async (event) => {
+      const message = event.data && event.data.data();
+      if (!message || message.senderUID === "system") return;
+
+      const {threadId} = event.params;
+      const db = admin.firestore();
+
+      const threadSnap = await db.doc(`threads/${threadId}`).get();
+      if (!threadSnap.exists) return;
+      const thread = threadSnap.data();
+
+      const recipient = (thread.participants || [])
+          .find((p) => p !== message.senderUID);
+      if (!recipient) return;
+
+      const userRef = db.doc(`users/${recipient}`);
+      const userSnap = await userRef.get();
+      const user = userSnap.exists ? userSnap.data() : {};
+
+      // Badge counts unread CONVERSATIONS (like iMessage), so only bump it
+      // when this thread flips from read to unread — i.e. the new message is
+      // the only unread one from the other participant.
+      const lastRead = (thread.lastRead || {})[recipient];
+      let recentQuery = db.collection(`threads/${threadId}/messages`)
+          .orderBy("createdAt", "desc")
+          .limit(10);
+      if (lastRead) {
+        recentQuery = recentQuery.where("createdAt", ">", lastRead);
+      }
+      const recent = await recentQuery.get();
+      const unreadFromOther = recent.docs
+          .filter((d) => d.data().senderUID === message.senderUID).length;
+      const threadWasAlreadyUnread = unreadFromOther > 1;
+
+      let unreadTotal = user.unreadTotal || 0;
+      if (!threadWasAlreadyUnread) {
+        unreadTotal += 1;
+        await userRef.set({unreadTotal}, {merge: true});
+      }
+
+      if (!user.fcmToken) return;
+
+      try {
+        await admin.messaging().send({
+          token: user.fcmToken,
+          notification: {
+            title: thread.nickname || "New message",
+            body: message.text || "sent you a message",
+          },
+          apns: {
+            payload: {
+              aps: {
+                badge: unreadTotal,
+                sound: "default",
+              },
+            },
+          },
+          data: {threadId},
+        });
+      } catch (err) {
+        // Token expired/uninstalled — drop it so we stop retrying
+        if (err.code === "messaging/registration-token-not-registered") {
+          await userRef.set({fcmToken: admin.firestore.FieldValue.delete()},
+              {merge: true});
+        } else {
+          console.error("push send failed", err);
+        }
+      }
+    });

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "here-functions",
+  "description": "Cloud Functions for the Here app (push notifications)",
+  "engines": {
+    "node": "20"
+  },
+  "main": "index.js",
+  "dependencies": {
+    "firebase-admin": "^13.0.0",
+    "firebase-functions": "^6.0.0"
+  },
+  "private": true
+}

--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,23 @@
+rules_version = '2';
+
+// Deploy with: firebase deploy --only storage
+// (or paste into Firebase Console → Storage → Rules)
+service firebase.storage {
+  match /b/{bucket}/o {
+
+    // Post photos live at posts/{authorUid}/{postFolder}/{image}.jpg.
+    // Anyone signed in can view; only the owner can upload into their own
+    // folder, and only reasonable-sized images.
+    match /posts/{userId}/{allPaths=**} {
+      allow read: if request.auth != null;
+      allow write: if request.auth != null
+        && request.auth.uid == userId
+        && request.resource.contentType.matches('image/.*')
+        && request.resource.size < 10 * 1024 * 1024;
+      allow delete: if request.auth != null
+        && request.auth.uid == userId;
+    }
+
+    // Everything outside posts/ is denied by default (no match = no access).
+  }
+}


### PR DESCRIPTION
#10 
  1. Lock-screen + banner notifications (the push pipeline)

  functions/index.js — the server half. A Cloud Function triggers whenever a document appears at threads/{threadId}/messages/{messageId}. It skips system messages, looks up the thread to find the other
  participant, bumps their unreadTotal counter in users/{uid}, and sends an FCM push (title = thread nickname, body = message text, sound, badge number, and a threadId data field for tap routing). If a token
  turns out to be dead (app uninstalled), it deletes it so it stops retrying. functions/package.json, firebase.json, and .firebaserc are just the deploy scaffolding around it.

  Here/Services/PushManager.swift — the client half. configure() makes it the delegate for both the notification center and FCM. requestPermissionAndRegister() shows the iOS permission prompt and registers with
  APNs. The MessagingDelegate extension receives the FCM device token and saves it to users/{uid} (buffering it if it arrives before anonymous sign-in finishes). The UNUserNotificationCenterDelegate extension
  does two jobs: willPresent shows the banner-with-sound when a push arrives while you're using the app — unless you're already inside that exact thread — and didReceive catches notification taps and publishes
  the thread ID.

  Here/Views/HereApp.swift — the AppDelegate now forwards the APNs device token to PushManager, and the launch task tells PushManager the uid after sign-in and triggers the permission prompt.

  Here/Views/ContentView.swift (routing part) — .onChange(of: push.tappedThreadId) takes the published thread ID from a notification tap and feeds it into the same navigateToThreadId → inbox flow the "Chat
  privately" button uses, so tapping a notification lands you inside that conversation.

  Here.entitlements + the HERE_PUSH_ENTITLEMENTS setting — the aps-environment entitlement Apple requires for push. After the fix just now, it's referenced through a variable that's empty by default in
  Configs/Shared.xcconfig, so your free-team builds ignore it entirely.

  Free tier: ✗ none of this delivers. No APNs key can be created, no push entitlement can be signed, so no lock-screen or banner notifications, full stop. The code all sits dormant and harmless: permission is
  requested (fine), APNs registration fails with a printed error (expected), no FCM token is stored, and the function — if you even deployed it — would find no token and just update the counter. When you upgrade
  later: uncomment one line in Shared.xcconfig, do the APNs key + Firebase upload, deploy the function, rebuild. No code changes.

  2. Home-screen icon counter

  Here/State/AppState.swift — syncBadge() computes the total unique chat unreads
  UNUserNotificationCenter.setBadgeCount(...), plus mirrors the number to users/{uid}.unreadTotal (that mirror only matters for push
  badges). It runs from both Firestore listeners, so any message arriving or being read updates the icon.

  Free tier: ✓ works, with one honest caveat. The badge permission is free. The number updates any time the app is running or briefly backgrounded. What it can't do without push is change while the app is fully
  closed — if someone messages you overnight, the icon shows the stale count until you next open the app. That limitation is physics, not code: only a push can update a badge on a closed app.

  3. Chats-tab counter

  Here/Models/ChatThread.swift — new lastRead: [String: Date] map (one timestamp per participant), decoded leniently so all existing threads default to "nothing read yet."

  Here/State/AppState.swift — unreadCount(in:) counts messages newer than your lastRead stamp that you didn't send (system messages excluded); totalUnread sums it; markThreadRead(threadId:) stamps
  lastRead.{yourUid} = now on the thread document.

  Here/Views/ChatDetailView.swift — marks the thread read when you open it and again as each message arrives while you're inside (so counts never accrue for a conversation you're looking at). Also sets/clears
  PushManager.activeThreadId, which is what suppresses redundant banners for the open thread.

  Here/Views/ContentView.swift + InboxView.swift — CustomTabItem gained an optional badge parameter that renders the gold pill on the Chats icon (caps at "99+"), fed by app.totalUnread; each ThreadCard now
  receives its real count, which lights up the gold circle badge that was already designed but hardcoded to zero.

  Free tier: ✓ fully works. This is live data from the Firestore listeners — both phones will show correct counts today.
  
  Sidenote: added QOL improvement to order chats by most recently updated