### PR TITLE
Chat Draft: only create chat on sent msg

### DIFF
--- a/Here/State/AppState.swift
+++ b/Here/State/AppState.swift
@@ -17,6 +17,11 @@ final class AppState: ObservableObject {
     @Published var threads: [ChatThread] = []
     @Published var messages: [String: [ChatMessage]] = [:]  // threadId -> messages
 
+    /// A chat the sender has opened but not yet written in. Lives only on this
+    /// device — nothing is created in Firestore (so the other person sees
+    /// nothing) until the first message is sent. Discarded if they back out.
+    @Published var draftThread: ChatThread?
+
     var uid: String { authService.uid ?? "" }
 
     init(authService: AuthService) {
@@ -112,7 +117,8 @@ final class AppState: ObservableObject {
 
     /// Stamps "read up to now" for the current user on a thread.
     func markThreadRead(threadId: String) async {
-        guard !uid.isEmpty else { return }
+        // Drafts have no Firestore document yet — nothing to stamp
+        guard !uid.isEmpty, threads.contains(where: { $0.id == threadId }) else { return }
         do {
             try await db.collection("threads").document(threadId).updateData([
                 "lastRead.\(uid)": Timestamp(date: Date())
@@ -205,7 +211,11 @@ final class AppState: ObservableObject {
 
     // MARK: - Threads
 
-    func createThreadFromPost(_ post: Post) async -> String? {
+    /// Opens a chat for a post WITHOUT creating anything in Firestore.
+    /// Returns the thread id to navigate to: an existing conversation, the
+    /// current draft, or a brand-new draft with its document id reserved
+    /// up front so navigation stays stable when it's materialized later.
+    func startChat(from post: Post) -> String? {
         guard !uid.isEmpty, post.id != nil else { return nil }
 
         // Don't chat with yourself
@@ -221,40 +231,55 @@ final class AppState: ObservableObject {
             return existing.id
         }
 
-        let thread = ChatThread(
+        // Re-enter the unsent draft for this post instead of making another
+        if let draft = draftThread, draft.postId == post.id {
+            return draft.id
+        }
+
+        let ref = db.collection("threads").document()
+        draftThread = ChatThread(
+            id: ref.documentID,
             postId: post.id,
             postTitle: post.title,
             participants: [uid, post.authorUID]
         )
+        return ref.documentID
+    }
 
-        do {
-            let ref = try db.collection("threads").addDocument(from: thread)
-
-            // Add an initial system message
-            let msg = ChatMessage(
-                text: "Started from: \"\(post.title)\"",
-                senderUID: "system"
-            )
-            try ref.collection("messages").addDocument(from: msg)
-
-            return ref.documentID
-        } catch {
-            print("Error creating thread: \(error.localizedDescription)")
-            return nil
-        }
+    /// Throws away the unsent draft (called when the sender leaves the chat
+    /// without writing anything).
+    func discardDraft(threadId: String) {
+        guard draftThread?.id == threadId else { return }
+        draftThread = nil
     }
 
     func sendMessage(threadId: String, text: String) async {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
 
-        // Check if frozen
-        guard let thread = threads.first(where: { $0.id == threadId }),
+        let isDraft = draftThread?.id == threadId
+
+        // Check if frozen (drafts are never frozen — they were just created)
+        guard let thread = threads.first(where: { $0.id == threadId })
+                ?? (isDraft ? draftThread : nil),
               !thread.isFrozen() else { return }
 
-        let msg = ChatMessage(text: trimmed, senderUID: uid)
-
         do {
+            // First message in a draft: create the real thread now. This is the
+            // moment the conversation appears on the other person's device.
+            if isDraft {
+                try db.collection("threads").document(threadId).setData(from: thread)
+                let sys = ChatMessage(
+                    text: "Started from: \"\(thread.postTitle)\"",
+                    senderUID: "system"
+                )
+                try db.collection("threads").document(threadId)
+                    .collection("messages")
+                    .addDocument(from: sys)
+                draftThread = nil
+            }
+
+            let msg = ChatMessage(text: trimmed, senderUID: uid)
             try db.collection("threads").document(threadId)
                 .collection("messages")
                 .addDocument(from: msg)

--- a/Here/Views/ChatDetailView.swift
+++ b/Here/Views/ChatDetailView.swift
@@ -82,6 +82,8 @@ struct ChatDetailView: View {
                         if PushManager.shared.activeThreadId == threadId {
                             PushManager.shared.activeThreadId = nil
                         }
+                        // Left without ever sending — the unsent draft evaporates
+                        app.discardDraft(threadId: threadId)
                     }
                 }
 

--- a/Here/Views/ContentView.swift
+++ b/Here/Views/ContentView.swift
@@ -74,11 +74,11 @@ struct ContentView: View {
                         posts: app.posts.filter { !$0.isPrivate || $0.authorUID == app.uid },
                         uid: app.uid,
                         onStartChat: { post in
-                            Task {
-                                if let threadId = await app.createThreadFromPost(post) {
-                                    navigateToThreadId = threadId
-                                    selectedTab = .inbox
-                                }
+                            // Opens a local draft — nothing exists in Firestore
+                            // (or on the other phone) until a message is sent
+                            if let threadId = app.startChat(from: post) {
+                                navigateToThreadId = threadId
+                                selectedTab = .inbox
                             }
                         },
                         onToggleLike: { post, alreadyLiked in

--- a/Here/Views/InboxView.swift
+++ b/Here/Views/InboxView.swift
@@ -22,7 +22,8 @@ struct InboxView: View {
 
     private func tryNavigate() {
         guard let threadId = navigateToThreadId,
-              app.threads.contains(where: { $0.id == threadId }) else { return }
+              app.threads.contains(where: { $0.id == threadId })
+                || app.draftThread?.id == threadId else { return }
         navigationPath = NavigationPath()
         navigationPath.append(threadId)
         navigateToThreadId = nil
@@ -63,7 +64,8 @@ struct InboxView: View {
             .background(Color.white)
             .navigationTitle("Chats")
             .navigationDestination(for: String.self) { threadId in
-                if let thread = app.threads.first(where: { $0.id == threadId }) {
+                if let thread = app.threads.first(where: { $0.id == threadId })
+                    ?? (app.draftThread?.id == threadId ? app.draftThread : nil) {
                     ChatDetailView(thread: thread, app: app)
                 }
             }


### PR DESCRIPTION
Current functionality: when someone starts chat, an empty chat shows up on both sender and receiver. 

New functionality: when sender starts chat, a new chat starts on their end, but until they send a message, no empty chat will show up on receiver end. if sender opts out of sending a message and leaves the new chat, the new chat will go away from sender list of chats until starting chat again.